### PR TITLE
Add CI script

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,0 +1,73 @@
+env:
+  intermediateArtifactName: dotnet-fromlinux-$CIRRUS_BUILD_ID.tar.gz
+
+Linux_task:
+  container:
+    image: ubuntu:xenial
+
+  packages_script: |
+    apt update
+    apt install -y libunwind8 libicu55 curl git clang-3.9 cmake make libc6-dev libssl-dev \
+                   libkrb5-dev libcurl4-openssl-dev zlib1g-dev liblldb-3.9-dev gettext \
+                   libicu-dev liblttng-ust-dev libkrb5-dev git locales
+
+  checkout repos_script: ./scripts/checkout.sh
+
+  generate locale_script: locale-gen en_US.UTF-8
+
+  build coreclr (managed)_script: |
+    cd $CIRRUS_WORKING_DIR/artifacts/sources/coreclr
+    bash -x ./build.sh -skiptests -skipmanagedtools -skipnative  -skipcrossgen -release -osgroup FreeBSD \
+        /p:osGroup=FreeBSD /p:PackageRid=freebsd-x64
+
+  build corefx (managed)_script: |
+    cd $CIRRUS_WORKING_DIR/artifacts/sources/corefx
+    ./build.sh -c Release --restore
+    ./build.sh -c Release --build  /p:osGroup=FreeBSD
+
+  publish_script: |
+    tar -cvzf $intermediateArtifactName $CIRRUS_WORKING_DIR/artifacts/sources/coreclr/bin/Product $CIRRUS_WORKING_DIR/artifacts/sources/corefx/artifacts/bin
+    curl -s -X POST --data-binary @$intermediateArtifactName http://$CIRRUS_HTTP_CACHE_HOST/$intermediateArtifactName
+
+FreeBSD_task:
+  freebsd_instance:
+    image_family: freebsd-12-0
+
+  depends_on: Linux
+
+  env:
+    HOME: /root
+    GH_API_TOKEN: ENCRYPTED[18bd1bb47022f0ec649d768dd4b822a44ed5e0e378ea7f8703b2a55cd6535ab90a50e915d09fe48eae451bdb9b63aeae]
+
+  install packages_script: ./scripts/packages.sh
+
+  checkout repos_script: ./scripts/checkout.sh
+
+  print info_script: |
+    . artifacts/config
+    echo "RUNTIME_VERSION: ${RUNTIME_VERSION}"
+    echo "RUNTIME_HASH: ${RUNTIME_HASH}"
+    cmake --version
+    git --version
+    clang --version
+
+  build coreclr (native)_script:
+    artifacts/sources/coreclr/build.sh -clang6.0 -skiptests -skipmanagedtools -skipmanaged -Release -portable
+
+  build corefx (native)_script:
+    artifacts/sources/corefx/src/Native/build-native.sh -release
+
+  build core-setup (native)_script: |
+    . artifacts/config
+    artifacts/sources/core-setup/src/corehost/build.sh  --configuration Release  --arch x64 \
+      --hostver ${RUNTIME_VERSION} --apphostver ${RUNTIME_VERSION} --fxrver ${RUNTIME_VERSION} --policyver ${RUNTIME_VERSION} --commithash ${RUNTIME_HASH}
+
+  publish_script: |
+    if test "$CIRRUS_TAG" != ""; then
+      artifactName=$CIRRUS_WORKING_DIR/dotnet-${CIRRUS_TAG}-freebsd.tar.gz
+      tar -cvzf $artifactName $CIRRUS_WORKING_DIR/artifacts/sources/coreclr/bin $CIRRUS_WORKING_DIR/artifacts/sources/corefx/artifacts/bin $CIRRUS_WORKING_DIR/artifacts/sources/core-setup/artifacts/bin
+      ./scripts/upload-github-release-asset.sh github_api_token=$GH_API_TOKEN owner=$CIRRUS_REPO_OWNER repo=$CIRRUS_REPO_NAME tag=$CIRRUS_TAG filename=$artifactName
+
+      curl -vO http://$CIRRUS_HTTP_CACHE_HOST/$intermediateArtifactName
+      ./scripts/upload-github-release-asset.sh github_api_token=$GH_API_TOKEN owner=$CIRRUS_REPO_OWNER repo=$CIRRUS_REPO_NAME tag=$CIRRUS_TAG filename=$intermediateArtifactName
+    fi

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # freebsd-bootstrap-cli
 .NET bootstrap cli project
 
+[![Build Status](https://api.cirrus-ci.com/github/wfurt/freebsd-bootstrap-cli.svg)](https://cirrus-ci.com/github/wfurt/freebsd-bootstrap-cli)
+
 This projects is aiming to automate creation of .NET cli on FreeBSD.
 This is not production ready - use https://github.com/dotnet/source-build for that.
 However to build .NET Core you have to have functional .NET Core. And you can get it right here. (if you are lucky) 

--- a/scripts/packages.sh
+++ b/scripts/packages.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-pkg install -y qemu-devel libunwind cmake llvm60 bash rsync
+pkg install -y libunwind cmake llvm60 bash rsync krb5 icu openssl lttng-ust git python

--- a/scripts/upload-github-release-asset.sh
+++ b/scripts/upload-github-release-asset.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env sh
+#
+# Modified version of: https://gist.github.com/stefanbuck/ce788fee19ab6eb0b4447a85fc99f447
+#
+#
+# This script accepts the following parameters:
+#
+# * owner
+# * repo
+# * tag
+# * filename
+# * github_api_token
+#
+# Script to upload a release asset using the GitHub API v3.
+#
+# Example:
+#
+# upload-github-release-asset.sh github_api_token=TOKEN owner=stefanbuck repo=playground tag=v0.1.0 filename=./build.zip
+#
+
+set -e
+
+# Validate settings.
+[ "$TRACE" ] && set -x
+
+for line in "$@"; do
+  eval "$line"
+done
+
+# Define variables.
+GH_API="https://api.github.com"
+GH_REPO="$GH_API/repos/$owner/$repo"
+GH_RELEASES="$GH_REPO/releases"
+GH_TAGS="$GH_RELEASES/tags/$tag"
+AUTH="Authorization: token $github_api_token"
+
+if test "$tag" == "LATEST"; then
+  GH_TAGS="$GH_REPO/releases/latest"
+fi
+
+# Validate token.
+curl -o /dev/null -sH "$AUTH" $GH_REPO || { echo "Error: Invalid repo, token or network issue!";  exit 1; }
+
+# Create a release from tag if it does not exist.
+curl -s -d "{\"tag_name\":\"$tag\"}" -H "$AUTH" "$GH_RELEASES" > /dev/null
+
+# Read asset tags.
+response=$(curl -sH "$AUTH" $GH_TAGS)
+
+# Get ID of the asset based on given filename.
+eval "$(echo "$response" | grep -m 1 "id.:" | grep -w id | tr : = | tr -cd '[[:alnum:]]=')"
+[ -n "$id" ] || { echo "Error: Failed to get release id for tag: $tag"; echo "$response" | awk 'length($0)<100' >&2; exit 1; }
+
+# Upload asset
+echo "Uploading asset... "
+
+# Construct url
+GH_ASSET="https://uploads.github.com/repos/$owner/$repo/releases/$id/assets?name=$(basename $filename)"
+
+curl "$GITHUB_OAUTH_BASIC" --data-binary @"$filename" -H "$AUTH" -H "Content-Type: application/octet-stream" $GH_ASSET


### PR DESCRIPTION
Add .cirrus.yml, which:

* builds managed bits on Debian and uploads `bin` directory to CirrusCI HTTP cache
* downloads bin directory on FreeBSD (dependent) task, and builds native bits
* on tag-push (e.g. `git tag v3.0.0 && git push --tags`), creates a github release (idempotently), and upload artifacts (tarball'd coreclr/bin, corefx/artifacts/bin and core-setup/artifacts/bin directories) to GitHub releases.

Examples:
* normal run: https://cirrus-ci.com/build/5763590854541312
* tag-pushed run: https://cirrus-ci.com/build/6637776368041984
* GitHub release: https://github.com/am11/freebsd-bootstrap-cli/releases/tag/v3.0.0