### PR TITLE
publish only runtime.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -22,10 +22,7 @@ Linux_task:
 
 
   publish_script: |
-    if [ -z "$CIRRUS_PR" ]; then
-      if test "$CIRRUS_TAG" != ""; then
-        CIRRUS_TAG=LATEST
-      fi
+    if test "$CIRRUS_TAG" != ""; then
       for artifactName in runtime/artifacts/packages/Release/Shipping/dotnet-runtime-5*tar.gz; do
         ./scripts/upload-github-release-asset.sh github_api_token=$GH_API_TOKEN owner=$CIRRUS_REPO_OWNER repo=$CIRRUS_REPO_NAME tag=$CIRRUS_TAG filename=$artifactName
       done

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -13,7 +13,7 @@ Linux_task:
 
   clone runtime_script: git clone https://github.com/dotnet/runtime --branch master --single-branch --depth 1
 
-  build runtime_script: runtime/build.sh -c release -cross -os FreeBSD -ci
+  build runtime_script: runtime/build.sh -c release -cross -os FreeBSD
 
   buildTests  runtime_script: |
     runtime/build.sh -c release -cross -os FreeBSD -ci -subset Libs.Tests /p:archivetests=true
@@ -22,8 +22,11 @@ Linux_task:
 
 
   publish_script: |
-    if test "$CIRRUS_TAG" != ""; then
-      for artifactName in runtime/artifacts/packages/Release/Shipping/*.*; do
+    if [ -z "$CIRRUS_PR" ]; then
+      if test "$CIRRUS_TAG" != ""; then
+        CIRRUS_TAG=LATEST
+      fi
+      for artifactName in runtime/artifacts/packages/Release/Shipping/dotnet-runtime-5*tar.gz; do
         ./scripts/upload-github-release-asset.sh github_api_token=$GH_API_TOKEN owner=$CIRRUS_REPO_OWNER repo=$CIRRUS_REPO_NAME tag=$CIRRUS_TAG filename=$artifactName
       done
     fi


### PR DESCRIPTION
This should publish dotnet-runtime-5.0.0-dev-freebsd-x64.tar.gz
I dropped -ci to preserve -dev in name until we have better release strategy. 

I'll try to get nugget packages to midget feed. 

cc: @am11  